### PR TITLE
feat: Add to address for redemptions

### DIFF
--- a/src/Redemption.sol
+++ b/src/Redemption.sol
@@ -241,8 +241,9 @@ abstract contract Redemption is PausableUpgradeable, Ownable2StepUpgradeable, IR
         returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
 
     /// @notice Abstract function that must be implemented by derived contracts
+    /// @param to The receiver address to deposit the redeemed USDC
     /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
-    function redeem(uint256 superstateTokenInAmount) external virtual;
+    function redeem(address to, uint256 superstateTokenInAmount) external virtual;
 
     /// @notice Abstract function that must be implemented by derived contracts
     /// @dev Must implement proper access controls

--- a/src/RedemptionIdle.sol
+++ b/src/RedemptionIdle.sol
@@ -45,8 +45,9 @@ contract RedemptionIdle is Redemption {
 
     /// @notice The ```redeem``` function allows users to redeem SUPERSTATE_TOKEN for USDC at the current oracle price
     /// @dev Will revert if oracle data is stale or there is not enough USDC in the contract
+    /// @param to The receiver address to deposit the redeemed USDC
     /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
-    function redeem(uint256 superstateTokenInAmount) external override {
+    function redeem(address to, uint256 superstateTokenInAmount) external override {
         _requireNotPaused();
 
         (uint256 usdcOutAmount,) = calculateUsdcOut(superstateTokenInAmount);
@@ -54,11 +55,12 @@ contract RedemptionIdle is Redemption {
         if (USDC.balanceOf(address(this)) < usdcOutAmount) revert InsufficientBalance();
 
         SUPERSTATE_TOKEN.safeTransferFrom({from: msg.sender, to: address(this), value: superstateTokenInAmount});
-        USDC.safeTransfer({to: msg.sender, value: usdcOutAmount});
+        USDC.safeTransfer({to: to, value: usdcOutAmount});
         ISuperstateToken(address(SUPERSTATE_TOKEN)).offchainRedeem(superstateTokenInAmount);
 
-        emit Redeem({
+        emit RedeemV2({
             redeemer: msg.sender,
+            to: to,
             superstateTokenInAmount: superstateTokenInAmount,
             usdcOutAmount: usdcOutAmount
         });

--- a/src/RedemptionYield.sol
+++ b/src/RedemptionYield.sol
@@ -56,8 +56,9 @@ contract RedemptionYield is Redemption {
 
     /// @notice The ```redeem``` function allows users to redeem SUPERSTATE_TOKEN for USDC at the current oracle price
     /// @dev Will revert if oracle data is stale or there is not enough USDC in the contract
+    /// @param to The receiver address to deposit the redeemed USDC
     /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
-    function redeem(uint256 superstateTokenInAmount) external override {
+    function redeem(address to, uint256 superstateTokenInAmount) external override {
         _requireNotPaused();
 
         (uint256 usdcOutAmount,) = calculateUsdcOut(superstateTokenInAmount);
@@ -68,8 +69,9 @@ contract RedemptionYield is Redemption {
         COMPOUND.withdrawTo({to: msg.sender, asset: address(USDC), amount: usdcOutAmount});
         ISuperstateToken(address(SUPERSTATE_TOKEN)).offchainRedeem(superstateTokenInAmount);
 
-        emit Redeem({
+        emit RedeemV2({
             redeemer: msg.sender,
+            to: to,
             superstateTokenInAmount: superstateTokenInAmount,
             usdcOutAmount: usdcOutAmount
         });

--- a/src/interfaces/IRedemption.sol
+++ b/src/interfaces/IRedemption.sol
@@ -19,9 +19,10 @@ interface IRedemption {
 
     /// @dev Event emitted when SUPERSTATE_TOKEN is redeemed for USDC
     /// @param redeemer The address of the entity redeeming
+    /// @param to The receiver address to deposit the redeemed USDC
     /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
     /// @param usdcOutAmount The amount of USDC the redeemer gets back
-    event Redeem(address indexed redeemer, uint256 superstateTokenInAmount, uint256 usdcOutAmount);
+    event RedeemV2(address indexed redeemer, address indexed to, uint256 superstateTokenInAmount, uint256 usdcOutAmount);
 
     /// @dev Event emitted when tokens are withdrawn
     /// @param token The address of the token being withdrawn
@@ -47,23 +48,23 @@ interface IRedemption {
 
     function getChainlinkPrice() external view returns (bool _isBadData, uint256 _updatedAt, uint256 _price);
     function calculateUsdcOut(uint256 superstateTokenInAmount)
-        external
-        view
-        returns (uint256 usdcOutAmount, uint256 usdPerUstbChainlinkRaw);
+    external
+    view
+    returns (uint256 usdcOutAmount, uint256 usdPerUstbChainlinkRaw);
     function calculateUstbIn(uint256 usdcOutAmount)
-        external
-        view
-        returns (uint256 ustbInAmount, uint256 usdPerUstbChainlinkRaw);
+    external
+    view
+    returns (uint256 ustbInAmount, uint256 usdPerUstbChainlinkRaw);
     function calculateFee(uint256 amount) external view returns (uint256);
     function maxUstbRedemptionAmount()
-        external
-        view
-        returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
+    external
+    view
+    returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
     function maximumOracleDelay() external view returns (uint256);
     function sweepDestination() external view returns (address);
     function redemptionFee() external view returns (uint256);
     function pause() external;
-    function redeem(uint256 superstateTokenInAmount) external;
+    function redeem(address to, uint256 superstateTokenInAmount) external;
     function setMaximumOracleDelay(uint256 _newMaxOracleDelay) external;
     function setSweepDestination(address _newSweepDestination) external;
     function setRedemptionFee(uint256 _newFee) external;

--- a/src/interfaces/IRedemption.sol
+++ b/src/interfaces/IRedemption.sol
@@ -22,7 +22,9 @@ interface IRedemption {
     /// @param to The receiver address to deposit the redeemed USDC
     /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
     /// @param usdcOutAmount The amount of USDC the redeemer gets back
-    event RedeemV2(address indexed redeemer, address indexed to, uint256 superstateTokenInAmount, uint256 usdcOutAmount);
+    event RedeemV2(
+        address indexed redeemer, address indexed to, uint256 superstateTokenInAmount, uint256 usdcOutAmount
+    );
 
     /// @dev Event emitted when tokens are withdrawn
     /// @param token The address of the token being withdrawn

--- a/src/interfaces/IRedemption.sol
+++ b/src/interfaces/IRedemption.sol
@@ -48,18 +48,18 @@ interface IRedemption {
 
     function getChainlinkPrice() external view returns (bool _isBadData, uint256 _updatedAt, uint256 _price);
     function calculateUsdcOut(uint256 superstateTokenInAmount)
-    external
-    view
-    returns (uint256 usdcOutAmount, uint256 usdPerUstbChainlinkRaw);
+        external
+        view
+        returns (uint256 usdcOutAmount, uint256 usdPerUstbChainlinkRaw);
     function calculateUstbIn(uint256 usdcOutAmount)
-    external
-    view
-    returns (uint256 ustbInAmount, uint256 usdPerUstbChainlinkRaw);
+        external
+        view
+        returns (uint256 ustbInAmount, uint256 usdPerUstbChainlinkRaw);
     function calculateFee(uint256 amount) external view returns (uint256);
     function maxUstbRedemptionAmount()
-    external
-    view
-    returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
+        external
+        view
+        returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
     function maximumOracleDelay() external view returns (uint256);
     function sweepDestination() external view returns (address);
     function redemptionFee() external view returns (uint256);

--- a/src/interfaces/IRedemptionIdleV2.sol
+++ b/src/interfaces/IRedemptionIdleV2.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {IRedemptionV2} from "./IRedemptionV2.sol";
+
+interface IRedemptionIdleV2 is IRedemptionV2 {}

--- a/src/interfaces/IRedemptionV2.sol
+++ b/src/interfaces/IRedemptionV2.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+interface IRedemptionV2 {
+    /// @notice The ```SetMaximumOracleDelay``` event is emitted when the max oracle delay is set
+    /// @param oldMaxOracleDelay The old max oracle delay
+    /// @param newMaxOracleDelay The new max oracle delay
+    event SetMaximumOracleDelay(uint256 oldMaxOracleDelay, uint256 newMaxOracleDelay);
+
+    /// @notice The ```SetSweepDestination``` event is emitted when the sweep destination is set
+    /// @param oldSweepDestination The old sweep destination
+    /// @param newSweepDestination The new sweep destination
+    event SetSweepDestination(address oldSweepDestination, address newSweepDestination);
+
+    /// @notice The ```SetRedemptionFee``` event is emitted when the redemption fee is set
+    /// @param oldFee The old fee
+    /// @param newFee The new fee
+    event SetRedemptionFee(uint256 oldFee, uint256 newFee);
+
+    /// @dev Event emitted when SUPERSTATE_TOKEN is redeemed for USDC
+    /// @param redeemer The address of the entity redeeming
+    /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
+    /// @param usdcOutAmount The amount of USDC the redeemer gets back
+    event Redeem(address indexed redeemer, uint256 superstateTokenInAmount, uint256 usdcOutAmount);
+
+    /// @dev Event emitted when tokens are withdrawn
+    /// @param token The address of the token being withdrawn
+    /// @param withdrawer The address of the caller
+    /// @param to The address receiving the tokens
+    /// @param amount The amount of token the redeemer gets back
+    event Withdraw(address indexed token, address indexed withdrawer, address indexed to, uint256 amount);
+
+    /// @dev Thrown when an argument is invalid
+    error BadArgs();
+
+    /// @dev Thrown when Chainlink Oracle data is bad
+    error BadChainlinkData();
+
+    /// @dev Thrown when owner tries to set the fee for a stablecoin too high
+    error FeeTooHigh();
+
+    /// @dev Thrown when there isn't enough token balance in the contract
+    error InsufficientBalance();
+
+    /// @dev Thrown if an attempt to call `renounceOwnership` is made
+    error RenounceOwnershipDisabled();
+
+    function getChainlinkPrice() external view returns (bool _isBadData, uint256 _updatedAt, uint256 _price);
+    function calculateUsdcOut(uint256 superstateTokenInAmount)
+        external
+        view
+        returns (uint256 usdcOutAmount, uint256 usdPerUstbChainlinkRaw);
+    function calculateUstbIn(uint256 usdcOutAmount)
+        external
+        view
+        returns (uint256 ustbInAmount, uint256 usdPerUstbChainlinkRaw);
+    function calculateFee(uint256 amount) external view returns (uint256);
+    function maxUstbRedemptionAmount()
+        external
+        view
+        returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
+    function maximumOracleDelay() external view returns (uint256);
+    function sweepDestination() external view returns (address);
+    function redemptionFee() external view returns (uint256);
+    function pause() external;
+    function redeem(uint256 superstateTokenInAmount) external;
+    function setMaximumOracleDelay(uint256 _newMaxOracleDelay) external;
+    function setSweepDestination(address _newSweepDestination) external;
+    function setRedemptionFee(uint256 _newFee) external;
+    function unpause() external;
+    function withdraw(address _token, address to, uint256 amount) external;
+    function withdrawToSweepDestination(uint256 amount) external;
+    function initialize(
+        address initialOwner,
+        uint256 _maximumOracleDelay,
+        address _sweepDestination,
+        uint256 _redemptionFee
+    ) external;
+}

--- a/src/interfaces/IRedemptionYieldV2.sol
+++ b/src/interfaces/IRedemptionYieldV2.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {IRedemptionV2} from "./IRedemptionV2.sol";
+
+interface IRedemptionYieldV2 is IRedemptionV2 {
+    /// @dev Event emitted when usdc is deposited into the contract via the deposit function
+    event Deposit(address indexed token, address indexed depositor, uint256 amount);
+
+    function deposit(uint256 usdcAmount) external;
+}

--- a/src/v1/RedemptionIdleV1.sol
+++ b/src/v1/RedemptionIdleV1.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {Redemption} from "src/Redemption.sol";
+import {RedemptionV2} from "src/v2/RedemptionV2.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 
 /// @title RedemptionIdle
 /// @notice Implementation of Redemption that keeps USDC idle in the contract
-contract RedemptionIdleV1 is Redemption {
+contract RedemptionIdleV1 is RedemptionV2 {
     using SafeERC20 for IERC20;
 
     /**
@@ -18,7 +18,7 @@ contract RedemptionIdleV1 is Redemption {
     uint256[500] private __inheritanceGap;
 
     constructor(address _superstateToken, address _superstateTokenChainlinkFeedAddress, address _usdc)
-        Redemption(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc)
+        RedemptionV2(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc)
     {}
 
     /// @notice The ```maxUstbRedemptionAmount``` function returns the maximum amount of SUPERSTATE_TOKEN that can be redeemed based on the amount of USDC in the contract

--- a/src/v1/RedemptionYieldV1.sol
+++ b/src/v1/RedemptionYieldV1.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {Redemption} from "src/Redemption.sol";
+import {RedemptionV2} from "src/v2/RedemptionV2.sol";
 import {IRedemptionYield} from "src/interfaces/IRedemptionYield.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 import {IComet} from "src/IComet.sol";
+import {RedemptionV2} from "../v2/RedemptionV2.sol";
 
 /// @title RedemptionYield
 /// @author Jon Walch and Max Wolff (Superstate) https://github.com/superstateinc
 /// @notice Implementation of Redemption that deploys idle USDC into Compound v3
-contract RedemptionYieldV1 is Redemption {
+contract RedemptionYieldV1 is RedemptionV2 {
     using SafeERC20 for IERC20;
 
     /**
@@ -28,7 +29,7 @@ contract RedemptionYieldV1 is Redemption {
         address _superstateTokenChainlinkFeedAddress,
         address _usdc,
         address _compound
-    ) Redemption(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc) {
+    ) RedemptionV2(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc) {
         COMPOUND = IComet(_compound);
     }
 

--- a/src/v1/RedemptionYieldV1.sol
+++ b/src/v1/RedemptionYieldV1.sol
@@ -7,7 +7,6 @@ import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 import {IComet} from "src/IComet.sol";
-import {RedemptionV2} from "../v2/RedemptionV2.sol";
 
 /// @title RedemptionYield
 /// @author Jon Walch and Max Wolff (Superstate) https://github.com/superstateinc

--- a/src/v2/RedemptionIdleV2.sol
+++ b/src/v2/RedemptionIdleV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import {RedemptionV2} from "./RedemptionV2.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ISuperstateToken} from "./ISuperstateToken.sol";
+import {ISuperstateToken} from "../ISuperstateToken.sol";
 
 /// @title RedemptionIdleV2.sol
 /// @notice Implementation of RedemptionV2.sol that keeps USDC idle in the contract
@@ -18,7 +18,7 @@ contract RedemptionIdleV2 is RedemptionV2 {
     uint256[500] private __inheritanceGap;
 
     constructor(address _superstateToken, address _superstateTokenChainlinkFeedAddress, address _usdc)
-        Redemption(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc)
+        RedemptionV2(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc)
     {}
 
     /// @notice The ```maxUstbRedemptionAmount``` function returns the maximum amount of SUPERSTATE_TOKEN that can be redeemed based on the amount of USDC in the contract

--- a/src/v2/RedemptionIdleV2.sol
+++ b/src/v2/RedemptionIdleV2.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {RedemptionV2} from "./RedemptionV2.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ISuperstateToken} from "./ISuperstateToken.sol";
+
+/// @title RedemptionIdleV2.sol
+/// @notice Implementation of RedemptionV2.sol that keeps USDC idle in the contract
+contract RedemptionIdleV2 is RedemptionV2 {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to inherit from new contracts
+     * without impacting the fields within `RedemptionIdleV2.sol`.
+     */
+    uint256[500] private __inheritanceGap;
+
+    constructor(address _superstateToken, address _superstateTokenChainlinkFeedAddress, address _usdc)
+        Redemption(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc)
+    {}
+
+    /// @notice The ```maxUstbRedemptionAmount``` function returns the maximum amount of SUPERSTATE_TOKEN that can be redeemed based on the amount of USDC in the contract
+    /// @return superstateTokenAmount The maximum amount of SUPERSTATE_TOKEN that can be redeemed
+    /// @return usdPerUstbChainlinkRaw The price used to calculate the superstateTokenAmount
+    function maxUstbRedemptionAmount()
+        external
+        view
+        override
+        returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw)
+    {
+        uint256 usdcOutAmountWithFee =
+            (USDC.balanceOf(address(this)) * FEE_DENOMINATOR) / (FEE_DENOMINATOR - redemptionFee);
+
+        (bool isBadData,, uint256 usdPerUstbChainlinkRaw_) = _getChainlinkPrice();
+        if (isBadData) revert BadChainlinkData();
+
+        usdPerUstbChainlinkRaw = usdPerUstbChainlinkRaw_;
+
+        // Round down, unlike `calculateUstbIn`, that way user doesn't send in more USTB than can be redeemed
+        superstateTokenAmount = (usdcOutAmountWithFee * CHAINLINK_FEED_PRECISION * SUPERSTATE_TOKEN_PRECISION)
+            / (usdPerUstbChainlinkRaw * USDC_PRECISION);
+    }
+
+    /// @notice The ```redeem``` function allows users to redeem SUPERSTATE_TOKEN for USDC at the current oracle price
+    /// @dev Will revert if oracle data is stale or there is not enough USDC in the contract
+    /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
+    function redeem(uint256 superstateTokenInAmount) external override {
+        _requireNotPaused();
+
+        (uint256 usdcOutAmount,) = calculateUsdcOut(superstateTokenInAmount);
+
+        if (USDC.balanceOf(address(this)) < usdcOutAmount) revert InsufficientBalance();
+
+        SUPERSTATE_TOKEN.safeTransferFrom({from: msg.sender, to: address(this), value: superstateTokenInAmount});
+        USDC.safeTransfer({to: msg.sender, value: usdcOutAmount});
+        ISuperstateToken(address(SUPERSTATE_TOKEN)).offchainRedeem(superstateTokenInAmount);
+
+        emit Redeem({
+            redeemer: msg.sender,
+            superstateTokenInAmount: superstateTokenInAmount,
+            usdcOutAmount: usdcOutAmount
+        });
+    }
+
+    /// @notice The ```withdraw``` function allows the owner to withdraw any type of ERC20
+    /// @dev Requires msg.sender to be the owner address
+    /// @param _token The address of the token to withdraw
+    /// @param to The address where the tokens are going
+    /// @param amount The amount of `_token` to withdraw
+    function withdraw(address _token, address to, uint256 amount) public override {
+        _checkOwner();
+        if (amount == 0) revert BadArgs();
+
+        IERC20 token = IERC20(_token);
+        uint256 balance = token.balanceOf(address(this));
+
+        if (balance < amount) revert InsufficientBalance();
+
+        token.safeTransfer({to: to, value: amount});
+        emit Withdraw({token: _token, withdrawer: msg.sender, to: to, amount: amount});
+    }
+}

--- a/src/v2/RedemptionV2.sol
+++ b/src/v2/RedemptionV2.sol
@@ -7,8 +7,8 @@ import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ISuperstateToken} from "./ISuperstateToken.sol";
-import {IRedemptionV2} from "./interfaces/IRedemptionV2.sol";
+import {ISuperstateToken} from "../ISuperstateToken.sol";
+import {IRedemptionV2} from "../interfaces/IRedemptionV2.sol";
 
 /// @title RedemptionV2.sol
 /// @author Jon Walch and Max Wolff (Superstate)

--- a/src/v2/RedemptionV2.sol
+++ b/src/v2/RedemptionV2.sol
@@ -8,12 +8,12 @@ import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contra
 import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ISuperstateToken} from "./ISuperstateToken.sol";
-import {IRedemption} from "./interfaces/IRedemption.sol";
+import {IRedemptionV2} from "./interfaces/IRedemptionV2.sol";
 
 /// @title RedemptionV2.sol
 /// @author Jon Walch and Max Wolff (Superstate)
 /// @notice Abstract contract that provides base functionality for Superstate Token redemption
-abstract contract RedemptionV2 is PausableUpgradeable, Ownable2StepUpgradeable, IRedemption {
+abstract contract RedemptionV2 is PausableUpgradeable, Ownable2StepUpgradeable, IRedemptionV2 {
     /**
      * @dev This empty reserved space is put in place to allow future versions to inherit from new contracts
      * without impacting the fields within `RedemptionV2.sol`.

--- a/src/v2/RedemptionV2.sol
+++ b/src/v2/RedemptionV2.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {AggregatorV3Interface} from "chainlink/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ISuperstateToken} from "./ISuperstateToken.sol";
+import {IRedemption} from "./interfaces/IRedemption.sol";
+
+/// @title RedemptionV2.sol
+/// @author Jon Walch and Max Wolff (Superstate)
+/// @notice Abstract contract that provides base functionality for Superstate Token redemption
+abstract contract RedemptionV2 is PausableUpgradeable, Ownable2StepUpgradeable, IRedemption {
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to inherit from new contracts
+     * without impacting the fields within `RedemptionV2.sol`.
+     */
+    uint256[500] private __inheritanceGap;
+
+    /// @notice Decimals of USDC
+    uint256 public constant USDC_DECIMALS = 6;
+
+    /// @notice Precision of USDC
+    uint256 public constant USDC_PRECISION = 10 ** USDC_DECIMALS;
+
+    /// @notice Decimals of SUPERSTATE_TOKEN
+    uint256 public constant SUPERSTATE_TOKEN_DECIMALS = 6;
+
+    /// @notice Precision of SUPERSTATE_TOKEN
+    uint256 public constant SUPERSTATE_TOKEN_PRECISION = 10 ** SUPERSTATE_TOKEN_DECIMALS;
+
+    /// @notice Base 10000 for 0.01% precision
+    uint256 public constant FEE_DENOMINATOR = 10_000;
+
+    /// @notice Chainlink aggregator
+    address public immutable CHAINLINK_FEED_ADDRESS;
+
+    /// @notice Decimals of SUPERSTATE_TOKEN/USD chainlink feed
+    uint8 public immutable CHAINLINK_FEED_DECIMALS;
+
+    /// @notice Precision of SUPERSTATE_TOKEN/USD chainlink feed
+    uint256 public immutable CHAINLINK_FEED_PRECISION;
+
+    /// @notice Lowest acceptable chainlink oracle price
+    uint256 public immutable MINIMUM_ACCEPTABLE_PRICE;
+
+    /// @notice The SUPERSTATE_TOKEN contract
+    IERC20 public immutable SUPERSTATE_TOKEN;
+
+    /// @notice The USDC contract
+    IERC20 public immutable USDC;
+
+    /// @notice Value, in seconds, that determines if chainlink data is too old
+    uint256 public maximumOracleDelay;
+
+    /// @notice Default where USDC gets swept to
+    address public sweepDestination;
+
+    // @notice A fee charged on incoming USDC
+    uint256 public redemptionFee;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new fields without impacting
+     * any contracts that inherit `RedemptionV2.sol`
+     */
+    uint256[100] private __additionalFieldsGap;
+
+    constructor(address _superstateToken, address _superstateTokenChainlinkFeedAddress, address _usdc) {
+        CHAINLINK_FEED_ADDRESS = _superstateTokenChainlinkFeedAddress;
+        CHAINLINK_FEED_DECIMALS = AggregatorV3Interface(CHAINLINK_FEED_ADDRESS).decimals();
+        CHAINLINK_FEED_PRECISION = 10 ** uint256(CHAINLINK_FEED_DECIMALS);
+        MINIMUM_ACCEPTABLE_PRICE = 7 * (10 ** uint256(CHAINLINK_FEED_DECIMALS));
+
+        SUPERSTATE_TOKEN = IERC20(_superstateToken);
+        USDC = IERC20(_usdc);
+
+        require(ERC20(_superstateToken).decimals() == SUPERSTATE_TOKEN_DECIMALS);
+        require(ERC20(_usdc).decimals() == USDC_DECIMALS);
+
+        _disableInitializers();
+    }
+
+    function initialize(
+        address initialOwner,
+        uint256 _maximumOracleDelay,
+        address _sweepDestination,
+        uint256 _redemptionFee
+    ) external initializer {
+        __Ownable_init(initialOwner);
+        __Ownable2Step_init();
+
+        _setMaximumOracleDelay(_maximumOracleDelay);
+        _setSweepDestination(_sweepDestination);
+
+        redemptionFee = _redemptionFee;
+        emit SetRedemptionFee({oldFee: 0, newFee: _redemptionFee});
+    }
+
+    receive() external payable {
+        revert();
+    }
+
+    fallback() external payable {
+        revert();
+    }
+
+    function calculateFee(uint256 amount) public view returns (uint256) {
+        return (amount * redemptionFee) / FEE_DENOMINATOR;
+    }
+
+    function _setRedemptionFee(uint256 _newFee) internal {
+        if (_newFee > 10) revert FeeTooHigh(); // Max 0.1% fee
+        if (redemptionFee == _newFee) revert BadArgs();
+        emit SetRedemptionFee({oldFee: redemptionFee, newFee: _newFee});
+        redemptionFee = _newFee;
+    }
+
+    /// @notice Sets redemption fee percentage (in basis points)
+    /// @dev Only callable by the admin
+    /// @dev Fee cannot exceed 10 basis points (0.1%)
+    /// @param _newFee New fee in basis points. 1 = 0.01%, 5 = 0.05%, 10 = 0.1%
+    function setRedemptionFee(uint256 _newFee) external {
+        _checkOwner();
+        _setRedemptionFee(_newFee);
+    }
+
+    /// @notice Invokes the {Pausable-_pause} internal function
+    function pause() external {
+        _checkOwner();
+        _requireNotPaused();
+        _pause();
+    }
+
+    /// @notice Invokes the {Pausable-_unpause} internal function
+    function unpause() external {
+        _checkOwner();
+        _requirePaused();
+        _unpause();
+    }
+
+    function _setSweepDestination(address _newSweepDestination) internal {
+        if (sweepDestination == _newSweepDestination || _newSweepDestination == address(0)) revert BadArgs();
+        emit SetSweepDestination({oldSweepDestination: sweepDestination, newSweepDestination: _newSweepDestination});
+        sweepDestination = _newSweepDestination;
+    }
+
+    /// @notice Sets the sweep destination for withdrawToSweepDestination
+    function setSweepDestination(address _newSweepDestination) external {
+        _checkOwner();
+        _setSweepDestination(_newSweepDestination);
+    }
+
+    function _setMaximumOracleDelay(uint256 _newMaxOracleDelay) internal {
+        if (maximumOracleDelay == _newMaxOracleDelay) revert BadArgs();
+        emit SetMaximumOracleDelay({oldMaxOracleDelay: maximumOracleDelay, newMaxOracleDelay: _newMaxOracleDelay});
+        maximumOracleDelay = _newMaxOracleDelay;
+    }
+
+    /// @notice Sets the max oracle delay to determine if Chainlink data is stale
+    function setMaximumOracleDelay(uint256 _newMaxOracleDelay) external {
+        _checkOwner();
+        _setMaximumOracleDelay(_newMaxOracleDelay);
+    }
+
+    function _getChainlinkPrice() internal view returns (bool _isBadData, uint256 _updatedAt, uint256 _price) {
+        (, int256 _answer,, uint256 _chainlinkUpdatedAt,) =
+            AggregatorV3Interface(CHAINLINK_FEED_ADDRESS).latestRoundData();
+
+        _isBadData =
+            _answer < int256(MINIMUM_ACCEPTABLE_PRICE) || ((block.timestamp - _chainlinkUpdatedAt) > maximumOracleDelay);
+        _updatedAt = _chainlinkUpdatedAt;
+        _price = uint256(_answer);
+    }
+
+    /// @notice Returns the chainlink price and the timestamp of the last update
+    function getChainlinkPrice() external view returns (bool _isBadData, uint256 _updatedAt, uint256 _price) {
+        return _getChainlinkPrice();
+    }
+
+    /**
+     * @notice The ```calculateUstbIn``` function calculates how many Superstate tokens you need to redeem to receive a specific USDC amount
+     * @param usdcOutAmount The desired amount of USDC to receive
+     * @return ustbInAmount The amount of Superstate tokens needed
+     * @return usdPerUstbChainlinkRaw The raw chainlink price used in calculation
+     */
+    function calculateUstbIn(uint256 usdcOutAmount)
+        public
+        view
+        returns (uint256 ustbInAmount, uint256 usdPerUstbChainlinkRaw)
+    {
+        if (usdcOutAmount == 0) revert BadArgs();
+
+        uint256 usdcOutAmountWithFee = (usdcOutAmount * FEE_DENOMINATOR) / (FEE_DENOMINATOR - redemptionFee);
+
+        (bool isBadData,, uint256 usdPerUstbChainlinkRaw_) = _getChainlinkPrice();
+        if (isBadData) revert BadChainlinkData();
+
+        usdPerUstbChainlinkRaw = usdPerUstbChainlinkRaw_;
+
+        // Round up by adding the denominator - 1 before division
+        uint256 numerator = usdcOutAmountWithFee * CHAINLINK_FEED_PRECISION * SUPERSTATE_TOKEN_PRECISION;
+        uint256 denominator = usdPerUstbChainlinkRaw * USDC_PRECISION;
+        ustbInAmount = (numerator + denominator - 1) / denominator;
+    }
+
+    /**
+     * @notice The ```calculateUsdcOut``` function calculates the total amount of USDC you'll receive for redeeming Superstate tokens
+     * @param superstateTokenInAmount The amount of Superstate tokens to redeem
+     * @return usdcOutAmount The amount of USDC received for redeeming superstateTokenInAmount
+     * @return usdPerUstbChainlinkRaw The raw chainlink price used in calculation
+     */
+    function calculateUsdcOut(uint256 superstateTokenInAmount)
+        public
+        view
+        returns (uint256 usdcOutAmount, uint256 usdPerUstbChainlinkRaw)
+    {
+        if (superstateTokenInAmount == 0) revert BadArgs();
+
+        (bool isBadData,, uint256 usdPerUstbChainlinkRaw_) = _getChainlinkPrice();
+        if (isBadData) revert BadChainlinkData();
+
+        usdPerUstbChainlinkRaw = usdPerUstbChainlinkRaw_;
+
+        uint256 rawUsdcAmount = (superstateTokenInAmount * usdPerUstbChainlinkRaw * USDC_PRECISION)
+            / (CHAINLINK_FEED_PRECISION * SUPERSTATE_TOKEN_PRECISION);
+
+        uint256 fee = calculateFee(rawUsdcAmount);
+        usdcOutAmount = rawUsdcAmount - fee;
+    }
+
+    /// @notice Abstract function that must be implemented by derived contracts
+    /// @return superstateTokenAmount The maximum amount of SUPERSTATE_TOKEN that can be redeemed
+    /// @return usdPerUstbChainlinkRaw The price used to calculate the superstateTokenAmount
+    function maxUstbRedemptionAmount()
+        external
+        view
+        virtual
+        returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw);
+
+    /// @notice Abstract function that must be implemented by derived contracts
+    /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
+    function redeem(uint256 superstateTokenInAmount) external virtual;
+
+    /// @notice Abstract function that must be implemented by derived contracts
+    /// @dev Must implement proper access controls
+    /// @param _token The address of the token to withdraw
+    /// @param to The address where the tokens are going
+    /// @param amount The amount of token to withdraw
+    function withdraw(address _token, address to, uint256 amount) public virtual;
+
+    /// @notice The ```withdrawToSweepDestination``` function calls ```withdraw``` with added safety rails
+    /// @param amount The amount of token to withdraw
+    function withdrawToSweepDestination(uint256 amount) external {
+        withdraw({_token: address(USDC), to: sweepDestination, amount: amount});
+    }
+
+    function renounceOwnership() public virtual override onlyOwner {
+        revert RenounceOwnershipDisabled();
+    }
+}

--- a/src/v2/RedemptionYieldV2.sol
+++ b/src/v2/RedemptionYieldV2.sol
@@ -5,8 +5,8 @@ import {RedemptionV2} from "./RedemptionV2.sol";
 import {IRedemptionYield} from "src/interfaces/IRedemptionYield.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ISuperstateToken} from "./ISuperstateToken.sol";
-import {IComet} from "./IComet.sol";
+import {ISuperstateToken} from "../ISuperstateToken.sol";
+import {IComet} from "../IComet.sol";
 
 /// @title RedemptionYieldV2.sol
 /// @author Jon Walch and Max Wolff (Superstate) https://github.com/superstateinc
@@ -28,7 +28,7 @@ contract RedemptionYieldV2 is RedemptionV2 {
         address _superstateTokenChainlinkFeedAddress,
         address _usdc,
         address _compound
-    ) Redemption(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc) {
+    ) RedemptionV2(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc) {
         COMPOUND = IComet(_compound);
     }
 

--- a/src/v2/RedemptionYieldV2.sol
+++ b/src/v2/RedemptionYieldV2.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {RedemptionV2} from "./RedemptionV2.sol";
+import {IRedemptionYield} from "src/interfaces/IRedemptionYield.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ISuperstateToken} from "./ISuperstateToken.sol";
+import {IComet} from "./IComet.sol";
+
+/// @title RedemptionYieldV2.sol
+/// @author Jon Walch and Max Wolff (Superstate) https://github.com/superstateinc
+/// @notice Implementation of RedemptionV2.sol that deploys idle USDC into Compound v3
+contract RedemptionYieldV2 is RedemptionV2 {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to inherit from new contracts
+     * without impacting the fields within `RedemptionYieldV2.sol`.
+     */
+    uint256[500] private __inheritanceGap;
+
+    /// @notice The CompoundV3 contract
+    IComet public immutable COMPOUND;
+
+    constructor(
+        address _superstateToken,
+        address _superstateTokenChainlinkFeedAddress,
+        address _usdc,
+        address _compound
+    ) Redemption(_superstateToken, _superstateTokenChainlinkFeedAddress, _usdc) {
+        COMPOUND = IComet(_compound);
+    }
+
+    /// @notice The ```maxUstbRedemptionAmount``` function returns the maximum amount of SUPERSTATE_TOKEN that can be redeemed based on the amount of USDC in the contract
+    /// @return superstateTokenAmount The maximum amount of SUPERSTATE_TOKEN that can be redeemed
+    /// @return usdPerUstbChainlinkRaw The price used to calculate the superstateTokenAmount
+    function maxUstbRedemptionAmount()
+        external
+        view
+        override
+        returns (uint256 superstateTokenAmount, uint256 usdPerUstbChainlinkRaw)
+    {
+        uint256 usdcOutAmountWithFee =
+            (COMPOUND.balanceOf(address(this)) * FEE_DENOMINATOR) / (FEE_DENOMINATOR - redemptionFee);
+
+        (bool isBadData,, uint256 usdPerUstbChainlinkRaw_) = _getChainlinkPrice();
+        if (isBadData) revert BadChainlinkData();
+
+        usdPerUstbChainlinkRaw = usdPerUstbChainlinkRaw_;
+
+        // Round down, unlike `calculateUstbIn`, that way user doesn't send in more USTB than can be redeemed
+        superstateTokenAmount = (usdcOutAmountWithFee * CHAINLINK_FEED_PRECISION * SUPERSTATE_TOKEN_PRECISION)
+            / (usdPerUstbChainlinkRaw * USDC_PRECISION);
+    }
+
+    /// @notice The ```redeem``` function allows users to redeem SUPERSTATE_TOKEN for USDC at the current oracle price
+    /// @dev Will revert if oracle data is stale or there is not enough USDC in the contract
+    /// @param superstateTokenInAmount The amount of SUPERSTATE_TOKEN to redeem
+    function redeem(uint256 superstateTokenInAmount) external override {
+        _requireNotPaused();
+
+        (uint256 usdcOutAmount,) = calculateUsdcOut(superstateTokenInAmount);
+
+        if (COMPOUND.balanceOf(address(this)) < usdcOutAmount) revert InsufficientBalance();
+
+        SUPERSTATE_TOKEN.safeTransferFrom({from: msg.sender, to: address(this), value: superstateTokenInAmount});
+        COMPOUND.withdrawTo({to: msg.sender, asset: address(USDC), amount: usdcOutAmount});
+        ISuperstateToken(address(SUPERSTATE_TOKEN)).offchainRedeem(superstateTokenInAmount);
+
+        emit Redeem({
+            redeemer: msg.sender,
+            superstateTokenInAmount: superstateTokenInAmount,
+            usdcOutAmount: usdcOutAmount
+        });
+    }
+
+    /// @notice The ```withdraw``` function allows the owner to withdraw any type of ERC20
+    /// @dev Requires msg.sender to be the owner address
+    /// @dev If you specify the compound (cUSDC) address, you'll withdraw from compound and receive USDC, every other token works as expected.
+    /// @dev Allows type(uint256).max withdraw from Compound when COMPOUND is the _token argument
+    /// @param _token The address of the token to withdraw
+    /// @param to The address where the tokens are going
+    /// @param amount The amount of `_token` to withdraw
+    function withdraw(address _token, address to, uint256 amount) public override {
+        _checkOwner();
+        if (amount == 0) revert BadArgs();
+
+        IERC20 token = IERC20(_token);
+        uint256 balance = token.balanceOf(address(this));
+
+        if (_token == address(COMPOUND)) {
+            if (amount == type(uint256).max) {
+                uint256 compoundBalance = COMPOUND.balanceOf(address(this));
+                COMPOUND.withdrawTo({to: to, asset: address(USDC), amount: amount});
+                emit Withdraw({token: address(USDC), withdrawer: msg.sender, to: to, amount: compoundBalance});
+            } else {
+                COMPOUND.withdrawTo({to: to, asset: address(USDC), amount: amount});
+                emit Withdraw({token: address(USDC), withdrawer: msg.sender, to: to, amount: amount});
+            }
+        } else {
+            if (balance < amount) revert InsufficientBalance();
+
+            token.safeTransfer({to: to, value: amount});
+            emit Withdraw({token: _token, withdrawer: msg.sender, to: to, amount: amount});
+        }
+    }
+
+    /// @notice The ```deposit``` function transfer USDC from the caller to this contract and then to Compound v3 to accrue interest
+    /// @dev Requires msg.sender to be the owner address
+    /// @param usdcAmount amount of approved usdc to put into this contract / deposit in compound
+    function deposit(uint256 usdcAmount) external {
+        _checkOwner();
+        if (usdcAmount == 0) revert BadArgs();
+
+        USDC.safeTransferFrom({from: msg.sender, to: address(this), value: usdcAmount});
+        USDC.approve({spender: address(COMPOUND), value: usdcAmount});
+        COMPOUND.supply({asset: address(USDC), amount: usdcAmount});
+
+        emit IRedemptionYield.Deposit({token: address(USDC), depositor: msg.sender, amount: usdcAmount});
+    }
+}

--- a/test/v1/RedemptionIdleV1.t.sol
+++ b/test/v1/RedemptionIdleV1.t.sol
@@ -323,7 +323,7 @@ contract RedemptionIdleTestV1 is Test {
         redemption.setSweepDestination(old);
     }
 
-    function testCantRedeemPaused() public {
+    function testCantRedeemPaused() public virtual {
         hoax(owner);
         redemption.pause();
 

--- a/test/v1/RedemptionIdleV1.t.sol
+++ b/test/v1/RedemptionIdleV1.t.sol
@@ -145,7 +145,7 @@ contract RedemptionIdleTestV1 is Test {
         redemption.withdraw(address(SUPERSTATE_TOKEN), owner, 1);
     }
 
-    function testRedeemAmountTooLarge() public {
+    function testRedeemAmountTooLarge() public virtual {
         uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
 
         vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
@@ -209,7 +209,7 @@ contract RedemptionIdleTestV1 is Test {
         assertEq(redemptionContractUsdcBalance, USDC_AMOUNT - redeemerUsdcBalance);
     }
 
-    function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public {
+    function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public virtual {
         (uint256 maxRedemptionAmount,) = redemption.maxUstbRedemptionAmount();
 
         superstateTokenRedeemAmount = bound(superstateTokenRedeemAmount, 1, maxRedemptionAmount);
@@ -247,7 +247,7 @@ contract RedemptionIdleTestV1 is Test {
         );
     }
 
-    function testRedeemBadDataOldDataFail() public {
+    function testRedeemBadDataOldDataFail() public virtual {
         vm.warp(block.timestamp + 5 days + 1);
 
         assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
@@ -262,7 +262,7 @@ contract RedemptionIdleTestV1 is Test {
         vm.stopPrank();
     }
 
-    function testRedeemAmountZeroFail() public {
+    function testRedeemAmountZeroFail() public virtual {
         hoax(SUPERSTATE_TOKEN_HOLDER);
         vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.redeem(0);
@@ -456,7 +456,7 @@ contract RedemptionIdleTestV1 is Test {
         assertEq(usdcOutVerify, 1_000_000_002);
     }
 
-    function testRedeemWithFee() public {
+    function testRedeemWithFee() public virtual {
         uint256 fee = 5; // 0.05%
         hoax(owner);
         redemption.setRedemptionFee(fee);

--- a/test/v1/RedemptionIdleV1.t.sol
+++ b/test/v1/RedemptionIdleV1.t.sol
@@ -10,7 +10,7 @@ import {Pausable} from "openzeppelin-contracts/contracts/utils/Pausable.sol";
 import {AllowList} from "ustb/src/AllowList.sol";
 import {Redemption} from "src/Redemption.sol";
 import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
-import {IRedemptionIdle} from "src/interfaces/IRedemptionIdle.sol";
+import {IRedemptionIdleV2} from "src/interfaces/IRedemptionIdleV2.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 import {IComet} from "src/IComet.sol";
 import {deployRedemptionIdleV1} from "script/RedemptionIdle.s.sol";
@@ -36,7 +36,7 @@ contract RedemptionIdleTestV1 is Test {
     uint256 public constant MAXIMUM_ORACLE_DELAY = 93_600;
 
     SuperstateOracle public oracle;
-    IRedemptionIdle public redemption;
+    IRedemptionIdleV2 public redemption;
     ITransparentUpgradeableProxy public redemptionProxy;
     ProxyAdmin public redemptionProxyAdmin;
 
@@ -83,7 +83,7 @@ contract RedemptionIdleTestV1 is Test {
             0
         );
 
-        redemption = IRedemptionIdle(address(proxy));
+        redemption = IRedemptionIdleV2(address(proxy));
         redemptionProxy = ITransparentUpgradeableProxy(payable(proxy));
         redemptionProxyAdmin = ProxyAdmin(getAdminAddress(address(redemptionProxy)));
 

--- a/test/v1/RedemptionIdleV1.t.sol
+++ b/test/v1/RedemptionIdleV1.t.sol
@@ -9,7 +9,7 @@ import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
 import {Pausable} from "openzeppelin-contracts/contracts/utils/Pausable.sol";
 import {AllowList} from "ustb/src/AllowList.sol";
 import {Redemption} from "src/Redemption.sol";
-import {IRedemption} from "src/interfaces/IRedemption.sol";
+import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
 import {IRedemptionIdle} from "src/interfaces/IRedemptionIdle.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 import {IComet} from "src/IComet.sol";
@@ -110,7 +110,7 @@ contract RedemptionIdleTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
         redemption.withdraw(address(USDC), owner, USDC_AMOUNT);
 
         assertEq(USDC.balanceOf(owner), USDC_AMOUNT);
@@ -121,7 +121,7 @@ contract RedemptionIdleTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
         redemption.withdrawToSweepDestination(USDC_AMOUNT);
 
         assertEq(USDC.balanceOf(address(this)), USDC_AMOUNT);
@@ -135,13 +135,13 @@ contract RedemptionIdleTestV1 is Test {
 
     function testWithdrawAmountZero() public {
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.withdraw(address(USDC), owner, 0);
     }
 
     function testWithdrawBalanceZero() public {
         hoax(owner);
-        vm.expectRevert(IRedemption.InsufficientBalance.selector);
+        vm.expectRevert(IRedemptionV2.InsufficientBalance.selector);
         redemption.withdraw(address(SUPERSTATE_TOKEN), owner, 1);
     }
 
@@ -151,7 +151,7 @@ contract RedemptionIdleTestV1 is Test {
         vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
         SUPERSTATE_TOKEN.approve(address(redemption), superstateTokenBalance);
         // Not enough USDC in the contract
-        vm.expectRevert(IRedemption.InsufficientBalance.selector);
+        vm.expectRevert(IRedemptionV2.InsufficientBalance.selector);
         redemption.redeem(superstateTokenBalance);
         vm.stopPrank();
     }
@@ -189,7 +189,7 @@ contract RedemptionIdleTestV1 is Test {
         });
         vm.expectEmit(true, true, true, true);
         // ~1e13, the original USDC amount
-        emit IRedemption.Redeem({
+        emit IRedemptionV2.Redeem({
             redeemer: SUPERSTATE_TOKEN_HOLDER,
             superstateTokenInAmount: superstateTokenAmount,
             usdcOutAmount: 9999999999996
@@ -264,7 +264,7 @@ contract RedemptionIdleTestV1 is Test {
 
     function testRedeemAmountZeroFail() public {
         hoax(SUPERSTATE_TOKEN_HOLDER);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.redeem(0);
     }
 
@@ -273,7 +273,7 @@ contract RedemptionIdleTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.SetMaximumOracleDelay({oldMaxOracleDelay: MAXIMUM_ORACLE_DELAY, newMaxOracleDelay: newDelay});
+        emit IRedemptionV2.SetMaximumOracleDelay({oldMaxOracleDelay: MAXIMUM_ORACLE_DELAY, newMaxOracleDelay: newDelay});
         redemption.setMaximumOracleDelay(newDelay);
 
         assertEq(newDelay, redemption.maximumOracleDelay());
@@ -291,7 +291,7 @@ contract RedemptionIdleTestV1 is Test {
         uint256 oldDelay = redemption.maximumOracleDelay();
 
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.setMaximumOracleDelay(oldDelay);
     }
 
@@ -301,7 +301,7 @@ contract RedemptionIdleTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.SetSweepDestination({oldSweepDestination: old, newSweepDestination: newSweepDest});
+        emit IRedemptionV2.SetSweepDestination({oldSweepDestination: old, newSweepDestination: newSweepDest});
         redemption.setSweepDestination(newSweepDest);
 
         assertEq(newSweepDest, redemption.sweepDestination());
@@ -319,7 +319,7 @@ contract RedemptionIdleTestV1 is Test {
         address old = redemption.sweepDestination();
 
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.setSweepDestination(old);
     }
 
@@ -360,7 +360,7 @@ contract RedemptionIdleTestV1 is Test {
     }
 
     function testCalculateUstbInAmountZero() public {
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.calculateUstbIn(0);
     }
 
@@ -387,7 +387,7 @@ contract RedemptionIdleTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.SetRedemptionFee({oldFee: 0, newFee: newFee});
+        emit IRedemptionV2.SetRedemptionFee({oldFee: 0, newFee: newFee});
         redemption.setRedemptionFee(newFee);
 
         assertEq(redemption.redemptionFee(), newFee);
@@ -397,7 +397,7 @@ contract RedemptionIdleTestV1 is Test {
         uint96 newFee = 11; // > 0.1%
 
         hoax(owner);
-        vm.expectRevert(IRedemption.FeeTooHigh.selector);
+        vm.expectRevert(IRedemptionV2.FeeTooHigh.selector);
         redemption.setRedemptionFee(newFee);
     }
 
@@ -411,7 +411,7 @@ contract RedemptionIdleTestV1 is Test {
         uint256 oldFee = redemption.redemptionFee();
 
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.setRedemptionFee(oldFee);
     }
 

--- a/test/v1/RedemptionYieldV1.t.sol
+++ b/test/v1/RedemptionYieldV1.t.sol
@@ -281,7 +281,7 @@ contract RedemptionYieldTestV1 is Test {
         assertEq(redemptionContractCusdcBalance, USDC_AMOUNT - redeemerUsdcBalance - lostToRounding);
     }
 
-    function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public {
+    function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public virtual {
         (uint256 maxRedemptionAmount,) = redemption.maxUstbRedemptionAmount();
 
         superstateTokenRedeemAmount = bound(superstateTokenRedeemAmount, 1, maxRedemptionAmount);
@@ -322,7 +322,7 @@ contract RedemptionYieldTestV1 is Test {
         );
     }
 
-    function testRedeemBadDataOldDataFail() public {
+    function testRedeemBadDataOldDataFail() public virtual {
         vm.warp(block.timestamp + 5 days + 1);
 
         assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
@@ -398,7 +398,7 @@ contract RedemptionYieldTestV1 is Test {
         redemption.setSweepDestination(old);
     }
 
-    function testCantRedeemPaused() public {
+    function testCantRedeemPaused() public virtual {
         hoax(owner);
         redemption.pause();
 
@@ -531,7 +531,7 @@ contract RedemptionYieldTestV1 is Test {
         assertEq(usdcOutVerify, 1_000_000_002);
     }
 
-    function testRedeemWithFee() public {
+    function testRedeemWithFee() public virtual {
         uint256 fee = 5; // 0.05%
         hoax(owner);
         redemption.setRedemptionFee(fee);

--- a/test/v1/RedemptionYieldV1.t.sol
+++ b/test/v1/RedemptionYieldV1.t.sol
@@ -337,7 +337,7 @@ contract RedemptionYieldTestV1 is Test {
         vm.stopPrank();
     }
 
-    function testRedeemAmountZeroFail() public {
+    function testRedeemAmountZeroFail() public virtual {
         hoax(SUPERSTATE_TOKEN_HOLDER);
         vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.redeem(0);

--- a/test/v1/RedemptionYieldV1.t.sol
+++ b/test/v1/RedemptionYieldV1.t.sol
@@ -9,7 +9,7 @@ import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
 import {Pausable} from "openzeppelin-contracts/contracts/utils/Pausable.sol";
 import {AllowList} from "ustb/src/AllowList.sol";
 import {Redemption} from "src/Redemption.sol";
-import {IRedemption} from "src/interfaces/IRedemption.sol";
+import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
 import {IRedemptionYield} from "src/interfaces/IRedemptionYield.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 import {IComet} from "src/IComet.sol";
@@ -112,7 +112,7 @@ contract RedemptionYieldTestV1 is Test {
     function testDepositBadArgs() public {
         vm.startPrank(owner);
         USDC.approve(address(redemption), 0);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.deposit(0);
         vm.stopPrank();
     }
@@ -132,7 +132,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: interestBalance});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: interestBalance});
         redemption.withdraw(address(COMPOUND), owner, interestBalance);
 
         assertEq(0, USDC.balanceOf(address(redemption)), "No USDC in the redemption contract");
@@ -154,7 +154,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: interestBalance});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: interestBalance});
         redemption.withdraw(address(COMPOUND), owner, type(uint256).max);
 
         assertEq(0, USDC.balanceOf(address(redemption)), "No USDC in the redemption contract");
@@ -169,7 +169,7 @@ contract RedemptionYieldTestV1 is Test {
     function testWithdraw() public {
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT - 1});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT - 1});
         redemption.withdraw(address(COMPOUND), owner, USDC_AMOUNT - 1);
 
         assertEq(USDC.balanceOf(owner), USDC_AMOUNT - 1);
@@ -180,7 +180,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
         redemption.withdraw(address(USDC), owner, USDC_AMOUNT);
 
         assertEq(USDC.balanceOf(owner), USDC_AMOUNT);
@@ -191,7 +191,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
+        emit IRedemptionV2.Withdraw({token: address(USDC), withdrawer: owner, to: owner, amount: USDC_AMOUNT});
         redemption.withdrawToSweepDestination(USDC_AMOUNT);
 
         assertEq(USDC.balanceOf(address(this)), USDC_AMOUNT);
@@ -205,13 +205,13 @@ contract RedemptionYieldTestV1 is Test {
 
     function testWithdrawAmountZero() public {
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.withdraw(address(USDC), owner, 0);
     }
 
     function testWithdrawBalanceZero() public {
         hoax(owner);
-        vm.expectRevert(IRedemption.InsufficientBalance.selector);
+        vm.expectRevert(IRedemptionV2.InsufficientBalance.selector);
         redemption.withdraw(address(SUPERSTATE_TOKEN), owner, 1);
     }
 
@@ -221,7 +221,7 @@ contract RedemptionYieldTestV1 is Test {
         vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
         SUPERSTATE_TOKEN.approve(address(redemption), superstateTokenBalance);
         // Not enough USDC in the contract
-        vm.expectRevert(IRedemption.InsufficientBalance.selector);
+        vm.expectRevert(IRedemptionV2.InsufficientBalance.selector);
         redemption.redeem(superstateTokenBalance);
         vm.stopPrank();
     }
@@ -259,7 +259,7 @@ contract RedemptionYieldTestV1 is Test {
         });
         vm.expectEmit(true, true, true, true);
         // ~1e13, the original USDC amount
-        emit IRedemption.Redeem({
+        emit IRedemptionV2.Redeem({
             redeemer: SUPERSTATE_TOKEN_HOLDER,
             superstateTokenInAmount: superstateTokenAmount,
             usdcOutAmount: 9999999999996
@@ -339,7 +339,7 @@ contract RedemptionYieldTestV1 is Test {
 
     function testRedeemAmountZeroFail() public {
         hoax(SUPERSTATE_TOKEN_HOLDER);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.redeem(0);
     }
 
@@ -348,7 +348,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.SetMaximumOracleDelay({oldMaxOracleDelay: MAXIMUM_ORACLE_DELAY, newMaxOracleDelay: newDelay});
+        emit IRedemptionV2.SetMaximumOracleDelay({oldMaxOracleDelay: MAXIMUM_ORACLE_DELAY, newMaxOracleDelay: newDelay});
         redemption.setMaximumOracleDelay(newDelay);
 
         assertEq(newDelay, redemption.maximumOracleDelay());
@@ -366,7 +366,7 @@ contract RedemptionYieldTestV1 is Test {
         uint256 oldDelay = redemption.maximumOracleDelay();
 
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.setMaximumOracleDelay(oldDelay);
     }
 
@@ -376,7 +376,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.SetSweepDestination({oldSweepDestination: old, newSweepDestination: newSweepDest});
+        emit IRedemptionV2.SetSweepDestination({oldSweepDestination: old, newSweepDestination: newSweepDest});
         redemption.setSweepDestination(newSweepDest);
 
         assertEq(newSweepDest, redemption.sweepDestination());
@@ -394,7 +394,7 @@ contract RedemptionYieldTestV1 is Test {
         address old = redemption.sweepDestination();
 
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.setSweepDestination(old);
     }
 
@@ -435,7 +435,7 @@ contract RedemptionYieldTestV1 is Test {
     }
 
     function testCalculateUstbInAmountZero() public {
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.calculateUstbIn(0);
     }
 
@@ -462,7 +462,7 @@ contract RedemptionYieldTestV1 is Test {
 
         hoax(owner);
         vm.expectEmit(true, true, true, true);
-        emit IRedemption.SetRedemptionFee({oldFee: 0, newFee: newFee});
+        emit IRedemptionV2.SetRedemptionFee({oldFee: 0, newFee: newFee});
         redemption.setRedemptionFee(newFee);
 
         assertEq(redemption.redemptionFee(), newFee);
@@ -472,7 +472,7 @@ contract RedemptionYieldTestV1 is Test {
         uint96 newFee = 11; // > 0.1%
 
         hoax(owner);
-        vm.expectRevert(IRedemption.FeeTooHigh.selector);
+        vm.expectRevert(IRedemptionV2.FeeTooHigh.selector);
         redemption.setRedemptionFee(newFee);
     }
 
@@ -486,7 +486,7 @@ contract RedemptionYieldTestV1 is Test {
         uint256 oldFee = redemption.redemptionFee();
 
         hoax(owner);
-        vm.expectRevert(IRedemption.BadArgs.selector);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
         redemption.setRedemptionFee(oldFee);
     }
 

--- a/test/v1/RedemptionYieldV1.t.sol
+++ b/test/v1/RedemptionYieldV1.t.sol
@@ -215,7 +215,7 @@ contract RedemptionYieldTestV1 is Test {
         redemption.withdraw(address(SUPERSTATE_TOKEN), owner, 1);
     }
 
-    function testRedeemAmountTooLarge() public {
+    function testRedeemAmountTooLarge() public virtual {
         uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
 
         vm.startPrank(SUPERSTATE_TOKEN_HOLDER);

--- a/test/v1/RedemptionYieldV1.t.sol
+++ b/test/v1/RedemptionYieldV1.t.sol
@@ -10,7 +10,7 @@ import {Pausable} from "openzeppelin-contracts/contracts/utils/Pausable.sol";
 import {AllowList} from "ustb/src/AllowList.sol";
 import {Redemption} from "src/Redemption.sol";
 import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
-import {IRedemptionYield} from "src/interfaces/IRedemptionYield.sol";
+import {IRedemptionYieldV2} from "src/interfaces/IRedemptionYieldV2.sol";
 import {ISuperstateTokenV2} from "src/interfaces/ISuperstateTokenV2.sol";
 import {IComet} from "src/IComet.sol";
 import {deployRedemptionYieldV1} from "script/RedemptionYield.s.sol";
@@ -37,7 +37,7 @@ contract RedemptionYieldTestV1 is Test {
     uint256 public constant MAXIMUM_ORACLE_DELAY = 93_600;
 
     SuperstateOracle public oracle;
-    IRedemptionYield public redemption;
+    IRedemptionYieldV2 public redemption;
     ITransparentUpgradeableProxy public redemptionProxy;
     ProxyAdmin public redemptionProxyAdmin;
 
@@ -79,7 +79,7 @@ contract RedemptionYieldTestV1 is Test {
             address(COMPOUND)
         );
 
-        redemption = IRedemptionYield(address(proxy));
+        redemption = IRedemptionYieldV2(address(proxy));
         redemptionProxy = ITransparentUpgradeableProxy(payable(proxy));
         redemptionProxyAdmin = ProxyAdmin(getAdminAddress(address(redemptionProxy)));
 
@@ -93,7 +93,7 @@ contract RedemptionYieldTestV1 is Test {
         vm.startPrank(owner);
         USDC.approve(address(redemption), USDC_AMOUNT);
         vm.expectEmit(true, true, true, true);
-        emit IRedemptionYield.Deposit({token: address(USDC), depositor: owner, amount: USDC_AMOUNT});
+        emit IRedemptionYieldV2.Deposit({token: address(USDC), depositor: owner, amount: USDC_AMOUNT});
         redemption.deposit(USDC_AMOUNT);
         vm.stopPrank();
 

--- a/test/v2/RedemptionIdleV2.t.sol
+++ b/test/v2/RedemptionIdleV2.t.sol
@@ -2,23 +2,23 @@
 pragma solidity ^0.8.28;
 
 import {RedemptionIdleTestV1} from "test/v1/RedemptionIdleV1.t.sol";
-import {RedemptionIdle} from "src/RedemptionIdle.sol";
+import {RedemptionIdleV2} from "src/v2/RedemptionIdleV2.sol";
 import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
 import {ISuperstateToken} from "src/ISuperstateToken.sol";
 
 contract RedemptionIdleTestV2 is RedemptionIdleTestV1 {
-    RedemptionIdle public redemptionV2;
+    RedemptionIdleV2 public redemptionV2;
 
-    function setUp() public override {
+    function setUp() public override virtual {
         // TODO: update test block number after deployment of new token contracts so tests pass
         super.setUp();
 
-        redemptionV2 = new RedemptionIdle(address(SUPERSTATE_TOKEN), address(oracle), address(USDC));
+        redemptionV2 = new RedemptionIdleV2(address(SUPERSTATE_TOKEN), address(oracle), address(USDC));
 
         redemptionProxyAdmin.upgradeAndCall(redemptionProxy, address(redemptionV2), "");
     }
 
-    function testRedeem() public override {
+    function testRedeem() public override virtual {
         assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
 
         uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);

--- a/test/v2/RedemptionIdleV2.t.sol
+++ b/test/v2/RedemptionIdleV2.t.sol
@@ -9,7 +9,7 @@ import {ISuperstateToken} from "src/ISuperstateToken.sol";
 contract RedemptionIdleTestV2 is RedemptionIdleTestV1 {
     RedemptionIdleV2 public redemptionV2;
 
-    function setUp() public override virtual {
+    function setUp() public virtual override {
         // TODO: update test block number after deployment of new token contracts so tests pass
         super.setUp();
 
@@ -18,7 +18,7 @@ contract RedemptionIdleTestV2 is RedemptionIdleTestV1 {
         redemptionProxyAdmin.upgradeAndCall(redemptionProxy, address(redemptionV2), "");
     }
 
-    function testRedeem() public override virtual {
+    function testRedeem() public virtual override {
         assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
 
         uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);

--- a/test/v2/RedemptionIdleV2.t.sol
+++ b/test/v2/RedemptionIdleV2.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {RedemptionIdleTestV1} from "test/v1/RedemptionIdleV1.t.sol";
 import {RedemptionIdle} from "src/RedemptionIdle.sol";
-import {IRedemption} from "src/interfaces/IRedemption.sol";
+import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
 import {ISuperstateToken} from "src/ISuperstateToken.sol";
 
 contract RedemptionIdleTestV2 is RedemptionIdleTestV1 {
@@ -51,7 +51,7 @@ contract RedemptionIdleTestV2 is RedemptionIdleTestV1 {
         });
         vm.expectEmit(true, true, true, true);
         // ~1e13, the original USDC amount
-        emit IRedemption.Redeem({
+        emit IRedemptionV2.Redeem({
             redeemer: SUPERSTATE_TOKEN_HOLDER,
             superstateTokenInAmount: superstateTokenAmount,
             usdcOutAmount: 9999999999996

--- a/test/v2/RedemptionYieldV2.t.sol
+++ b/test/v2/RedemptionYieldV2.t.sol
@@ -9,16 +9,17 @@ import {ISuperstateToken} from "src/ISuperstateToken.sol";
 contract RedemptionYieldTestV2 is RedemptionYieldTestV1 {
     RedemptionYieldV2 public redemptionV2;
 
-    function setUp() public override virtual {
+    function setUp() public virtual override {
         // TODO: update test block number after deployment of new token contracts so tests pass
         super.setUp();
 
-        redemptionV2 = new RedemptionYieldV2(address(SUPERSTATE_TOKEN), address(oracle), address(USDC), address(COMPOUND));
+        redemptionV2 =
+            new RedemptionYieldV2(address(SUPERSTATE_TOKEN), address(oracle), address(USDC), address(COMPOUND));
 
         redemptionProxyAdmin.upgradeAndCall(redemptionProxy, address(redemptionV2), "");
     }
 
-    function testRedeem() public override virtual {
+    function testRedeem() public virtual override {
         assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
 
         uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);

--- a/test/v2/RedemptionYieldV2.t.sol
+++ b/test/v2/RedemptionYieldV2.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {RedemptionYieldTestV1} from "test/v1/RedemptionYieldV1.t.sol";
 import {RedemptionYield} from "src/RedemptionYield.sol";
-import {IRedemption} from "src/interfaces/IRedemption.sol";
+import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
 import {ISuperstateToken} from "src/ISuperstateToken.sol";
 
 contract RedemptionYieldV2 is RedemptionYieldTestV1 {
@@ -51,7 +51,7 @@ contract RedemptionYieldV2 is RedemptionYieldTestV1 {
         });
         vm.expectEmit(true, true, true, true);
         // ~1e13, the original USDC amount
-        emit IRedemption.Redeem({
+        emit IRedemptionV2.Redeem({
             redeemer: SUPERSTATE_TOKEN_HOLDER,
             superstateTokenInAmount: superstateTokenAmount,
             usdcOutAmount: 9999999999996

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -11,7 +11,6 @@ import {SuperstateOracle} from "src/oracle/SuperstateOracle.sol";
 contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     RedemptionIdle public redemptionV3;
     address public constant SUPERSTATE_REDEMPTION_RECEIVER = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
-//    ProxyAdmin public redemptionProxyAdminV3;
 
     function setUp() public override {
         // TODO: update test block number after deployment of new token contracts so tests pass

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -6,6 +6,7 @@ import {IRedemption} from "src/interfaces/IRedemption.sol";
 import {ISuperstateToken} from "src/ISuperstateToken.sol";
 import {RedemptionIdle} from "src/RedemptionIdle.sol";
 import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
+import {SuperstateOracle} from "src/oracle/SuperstateOracle.sol";
 
 contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     RedemptionIdle public redemptionV3;
@@ -61,6 +62,7 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
             superstateTokenInAmount: superstateTokenAmount,
             usdcOutAmount: 9999999999996
         });
+
         redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, superstateTokenAmount);
         vm.stopPrank();
 
@@ -147,6 +149,18 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     }
 
     function testRedeemWithFee() public override {
+        uint256 fee = 5; // 0.05%
+        hoax(owner);
+        redemption.setRedemptionFee(fee);
 
+        (uint256 superstateTokenAmount,) = redemption.maxUstbRedemptionAmount();
+
+        vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
+        SUPERSTATE_TOKEN.approve(address(redemption), superstateTokenAmount);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, superstateTokenAmount);
+        vm.stopPrank();
+
+        uint256 redeemerUsdcBalance = USDC.balanceOf(SUPERSTATE_REDEMPTION_RECEIVER);
+        assertEq(redeemerUsdcBalance, 9_999_999_999_998);
     }
 }

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -5,6 +5,7 @@ import {RedemptionIdleTestV2} from "test/v2/RedemptionIdleV2.t.sol";
 import {IRedemption} from "src/interfaces/IRedemption.sol";
 import {ISuperstateToken} from "src/ISuperstateToken.sol";
 import {RedemptionIdle} from "src/RedemptionIdle.sol";
+import {IRedemptionV2} from "src/interfaces/IRedemptionV2.sol";
 
 contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     RedemptionIdle public redemptionV3;
@@ -76,7 +77,14 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     }
 
     function testRedeemAmountTooLarge() public override {
+        uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
 
+        vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
+        SUPERSTATE_TOKEN.approve(address(redemption), superstateTokenBalance);
+        // Not enough USDC in the contract
+        vm.expectRevert(IRedemptionV2.InsufficientBalance.selector);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, superstateTokenBalance);
+        vm.stopPrank();
     }
 
     function testRedeemAmountZeroFail() public override {

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -124,7 +124,7 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
         vm.stopPrank();
 
         uint256 redeemerUstbBalanceAfter = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
-        uint256 redeemerUsdcBalanceAfter = USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER);
+        uint256 receiverUsdcBalanceAfter = USDC.balanceOf(SUPERSTATE_REDEMPTION_RECEIVER);
         uint256 redemptionContractUsdcBalanceAfter = USDC.balanceOf(address(redemption));
 
         assertEq(SUPERSTATE_TOKEN.balanceOf(address(redemption)), 0, "Contract has 0 SUPERSTATE_TOKEN balance");
@@ -136,13 +136,13 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
         );
 
         assertEq(
-            redeemerUsdcBalanceAfter,
+            receiverUsdcBalanceAfter,
             USDC_AMOUNT - redemptionContractUsdcBalanceAfter,
-            "Redeemer has proper USDC balance"
+            "Receiver has proper USDC balance"
         );
         assertEq(
             redemptionContractUsdcBalanceAfter,
-            USDC_AMOUNT - redeemerUsdcBalanceAfter,
+            USDC_AMOUNT - receiverUsdcBalanceAfter,
             "Contract has proper USDC balance"
         );
     }

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -88,7 +88,9 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     }
 
     function testRedeemAmountZeroFail() public override {
-
+        hoax(SUPERSTATE_TOKEN_HOLDER);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, 0);
     }
 
     function testRedeemBadDataOldDataFail() public override {

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -94,7 +94,18 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     }
 
     function testRedeemBadDataOldDataFail() public override {
+        vm.warp(block.timestamp + 5 days + 1);
 
+        assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
+
+        vm.expectRevert(SuperstateOracle.StaleCheckpoint.selector);
+        redemption.maxUstbRedemptionAmount();
+
+        vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
+        SUPERSTATE_TOKEN.approve(address(redemption), 100);
+        vm.expectRevert(SuperstateOracle.StaleCheckpoint.selector);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, 100);
+        vm.stopPrank();
     }
 
     function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public override {

--- a/test/v3/RedemptionIdleV3.t.sol
+++ b/test/v3/RedemptionIdleV3.t.sol
@@ -109,7 +109,41 @@ contract RedemptionIdleTestV3 is RedemptionIdleTestV2 {
     }
 
     function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public override {
+        (uint256 maxRedemptionAmount,) = redemption.maxUstbRedemptionAmount();
 
+        superstateTokenRedeemAmount = bound(superstateTokenRedeemAmount, 1, maxRedemptionAmount);
+
+        assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
+
+        uint256 redeemerUstbBalanceBefore = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
+
+        vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
+        SUPERSTATE_TOKEN.approve(address(redemption), superstateTokenRedeemAmount);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, superstateTokenRedeemAmount);
+        vm.stopPrank();
+
+        uint256 redeemerUstbBalanceAfter = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
+        uint256 redeemerUsdcBalanceAfter = USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER);
+        uint256 redemptionContractUsdcBalanceAfter = USDC.balanceOf(address(redemption));
+
+        assertEq(SUPERSTATE_TOKEN.balanceOf(address(redemption)), 0, "Contract has 0 SUPERSTATE_TOKEN balance");
+
+        assertEq(
+            redeemerUstbBalanceAfter,
+            redeemerUstbBalanceBefore - superstateTokenRedeemAmount,
+            "Redeemer has proper SUPERSTATE_TOKEN balance"
+        );
+
+        assertEq(
+            redeemerUsdcBalanceAfter,
+            USDC_AMOUNT - redemptionContractUsdcBalanceAfter,
+            "Redeemer has proper USDC balance"
+        );
+        assertEq(
+            redemptionContractUsdcBalanceAfter,
+            USDC_AMOUNT - redeemerUsdcBalanceAfter,
+            "Contract has proper USDC balance"
+        );
     }
 
     function testRedeemWithFee() public override {

--- a/test/v3/RedemptionYieldV3.t.sol
+++ b/test/v3/RedemptionYieldV3.t.sol
@@ -87,7 +87,9 @@ contract RedemptionYieldTestV3 is RedemptionYieldTestV2 {
     }
 
     function testRedeemAmountZeroFail() public override {
-
+        hoax(SUPERSTATE_TOKEN_HOLDER);
+        vm.expectRevert(IRedemptionV2.BadArgs.selector);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, 0);
     }
 
     function testRedeemBadDataOldDataFail() public override {

--- a/test/v3/RedemptionYieldV3.t.sol
+++ b/test/v3/RedemptionYieldV3.t.sol
@@ -76,7 +76,14 @@ contract RedemptionYieldTestV3 is RedemptionYieldTestV2 {
     }
 
     function testRedeemAmountTooLarge() public override {
+        uint256 superstateTokenBalance = SUPERSTATE_TOKEN.balanceOf(SUPERSTATE_TOKEN_HOLDER);
 
+        vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
+        SUPERSTATE_TOKEN.approve(address(redemption), superstateTokenBalance);
+        // Not enough USDC in the contract
+        vm.expectRevert(IRedemptionV2.InsufficientBalance.selector);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, superstateTokenBalance);
+        vm.stopPrank();
     }
 
     function testRedeemAmountZeroFail() public override {

--- a/test/v3/RedemptionYieldV3.t.sol
+++ b/test/v3/RedemptionYieldV3.t.sol
@@ -93,7 +93,18 @@ contract RedemptionYieldTestV3 is RedemptionYieldTestV2 {
     }
 
     function testRedeemBadDataOldDataFail() public override {
+        vm.warp(block.timestamp + 5 days + 1);
 
+        assertEq(USDC.balanceOf(SUPERSTATE_TOKEN_HOLDER), 0);
+
+        vm.expectRevert(SuperstateOracle.StaleCheckpoint.selector);
+        redemption.maxUstbRedemptionAmount();
+
+        vm.startPrank(SUPERSTATE_TOKEN_HOLDER);
+        SUPERSTATE_TOKEN.approve(address(redemption), 100);
+        vm.expectRevert(SuperstateOracle.StaleCheckpoint.selector);
+        redemptionV3.redeem(SUPERSTATE_REDEMPTION_RECEIVER, 100);
+        vm.stopPrank();
     }
 
     function testRedeemFuzz(uint256 superstateTokenRedeemAmount) public override {


### PR DESCRIPTION
This PR updates the redemption function and emitted event. The redemption function now accepts a _to_ address parameter that redeemed USDC can be deposited into instead of using msg.sender. The redeem event has been renamed to redeemV2 to support indexing events with the new parameter. 